### PR TITLE
export variables from conf script

### DIFF
--- a/conf.sh
+++ b/conf.sh
@@ -13,5 +13,5 @@
 DATA_ROOT_DIR=/tmp/data
 PERF_DIR=$HOME/git/agile/performance-monitor
 ARCH=x86_64
-ADDR=http://localhost:1880
-PI_HOST=localhost
+export AADDR=http://localhost:1880
+export API_HOST=localhost


### PR DESCRIPTION
After rebooting my machine, I realized that I had exported by hand the variables in the conf.sh that are needed outside, so ADDS and PI_HOST were not actually used yet.